### PR TITLE
Remove nginx_common dependency.

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -23,5 +23,4 @@ dependencies:
     # httpd_site_robots_txt:
     # httpd_site_robots_txt_dir:
     # httpd_site_robots_txt_filename:
-  - ajsalminen.nginx_common
 allow_duplicates: yes


### PR DESCRIPTION
nginx_site is required before nginx is installed, as it is a dependency
in nginx role. nginx_common needs /etc/nginx to exists.